### PR TITLE
Enable CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-on: [push]
-
 name: CI
-
+on:
+  push
+  pull_request
 jobs:
   build_and_test:
     name: many-rs build and tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
-  push
-  pull_request
+  - push
+  - pull_request
 jobs:
   build_and_test:
     name: many-rs build and tests


### PR DESCRIPTION
CI will run when a PR is opened, synchronized or reopened.

When a first-time contributor submits a pull request to a public
repository, a maintainer with write access may need to approve running
workflows on the pull request.

See links in https://github.com/l-1-labs/many-rs/issues/37 for details.

Fixes #37 